### PR TITLE
Adicionado suporte para POST na rota /emails com headers autorization

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "debug": "cross-env NODE_ENV='development' nodemon --inspect ./server.js --exec babel-node",
     "test-integration": "cross-env NODE_ENV='test' nyc --reporter=text --reporter=html --reporter=lcov mocha --require @babel/register --recursive './test/integration'",
     "test": "cross-env NODE_ENV='test' nyc --reporter=text --reporter=html --reporter=lcov mocha --require @babel/register --recursive './test/**/*.test.js'",
-    "coveralls":"nyc npm test && nyc report --reporter=text-lcov | coveralls"
+    "coveralls": "nyc npm test && nyc report --reporter=text-lcov | coveralls"
   },
   "keywords": [],
   "author": "",

--- a/src/controllers/EmailsController.js
+++ b/src/controllers/EmailsController.js
@@ -1,3 +1,4 @@
+import * as requestUtils from '../infra/utils/requestUtils'
 import HttpStatus from 'http-status'
 
 export class EmailsController {
@@ -8,14 +9,12 @@ export class EmailsController {
 
     sendEmail = (req,res) => {
 
-        console.log(`ola`);
-        
-
         this.emailRepository
             .create(req.body)
             .then(
                 (res) => {
-                    res.json(HttpStatus.OK)
+                    requestUtils.defaultResponse(res, email, HttpStatus.OK)
+                    //res.json(HttpStatus.OK)
                 }
             )
             .catch(

--- a/src/controllers/EmailsController.js
+++ b/src/controllers/EmailsController.js
@@ -11,15 +11,21 @@ export class EmailsController {
 
         this.emailRepository
             .create(req.body)
-            .then(
-                (res) => {
-                    requestUtils.defaultResponse(res, email, HttpStatus.OK)
-                    //res.json(HttpStatus.OK)
-                }
-            )
+            .then(createdEmail => {
+                requestUtils.defaultResponse(res, createdEmail, HttpStatus.CREATED)
+            })
             .catch(
-                () => {
-                    res.json(HttpStatus.INTERNAL_SERVER_ERROR)
+                error => {
+                    error = {
+                        message: error.message,
+                        body: error.errors.map((item) => {
+                            return {
+                                message: item.message,
+                                value: item.value
+                            }
+                        })
+                    }
+                    requestUtils.errorResponse(res, error, HttpStatus.INTERNAL_SERVER_ERROR)
                 }
             )
     }

--- a/src/controllers/EmailsController.js
+++ b/src/controllers/EmailsController.js
@@ -1,0 +1,27 @@
+import HttpStatus from 'http-status'
+
+export class EmailsController {
+    
+    constructor(emailRepository){
+        this.emailRepository = emailRepository
+    }
+
+    sendEmail = (req,res) => {
+
+        console.log(`ola`);
+        
+
+        this.emailRepository
+            .create(req.body)
+            .then(
+                (res) => {
+                    res.json(HttpStatus.OK)
+                }
+            )
+            .catch(
+                () => {
+                    res.json(HttpStatus.INTERNAL_SERVER_ERROR)
+                }
+            )
+    }
+}

--- a/src/controllers/schemas/authSchema.js
+++ b/src/controllers/schemas/authSchema.js
@@ -1,0 +1,5 @@
+import Joi from 'joi'
+
+export const authSchema = Joi.object({
+    authorization: Joi.string().required()
+});

--- a/src/infra/validator.js
+++ b/src/infra/validator.js
@@ -87,7 +87,6 @@ export const validatorMiddleware = (validations) => (req,res,next) => {
     const validator = new Validator(req,validations)
 
     validator.validate()
-    
     req.validations = {
         hasErrors: validator.hasErrors,
         errors: {

--- a/src/infra/validator.js
+++ b/src/infra/validator.js
@@ -9,6 +9,7 @@ class Validator {
         for(const validation in validations) {
             this._validations[validation] = new Validation(validation, validations[validation])
         }
+
     }
 
     validate = () => {
@@ -53,7 +54,7 @@ class Validation {
     }
 
     isHeader(validationType) {
-        return validationType === 'header'
+        return validationType === 'headers'
     }
 
     isValidValidationType(validationType) {
@@ -82,6 +83,7 @@ class Validation {
 }
 
 export const validatorMiddleware = (validations) => (req,res,next) => {
+    
     const validator = new Validator(req,validations)
 
     validator.validate()

--- a/src/models/emails.js
+++ b/src/models/emails.js
@@ -10,9 +10,6 @@ export default (sequelize, DataType) => {
         from: {
             type: DataType.STRING,
             allowNull: false,
-            unique: {
-                args: true
-            },
             validate: {
                 isEmail: true
             }
@@ -20,9 +17,6 @@ export default (sequelize, DataType) => {
         to: {
             type: DataType.STRING,
             allowNull: false,
-            unique: {
-                args: true
-            },
             validate: {
                 isEmail: true
             }

--- a/src/models/emails.js
+++ b/src/models/emails.js
@@ -1,0 +1,39 @@
+export default (sequelize, DataType) => {
+
+    const Emails = sequelize.define('emails', {
+        id: {
+            primaryKey: true,
+            type: DataType.UUID,
+            allowNull: false,
+            defaultValue: DataType.UUIDV4
+        },
+        from: {
+            type: DataType.STRING,
+            allowNull: false,
+            unique: {
+                args: true
+            },
+            validate: {
+                isEmail: true
+            }
+        },
+        to: {
+            type: DataType.STRING,
+            allowNull: false,
+            unique: {
+                args: true
+            },
+            validate: {
+                isEmail: true
+            }
+        },
+        subject: {
+            type: DataType.STRING
+        }, 
+        content: {
+            type: DataType.STRING
+        }
+    })
+
+    return Emails
+}

--- a/src/repositories/EmailsRepository.js
+++ b/src/repositories/EmailsRepository.js
@@ -1,0 +1,10 @@
+export class EmailsRepository {
+    
+    constructor(emails){
+        this.emails = emails;
+    }
+
+    create = (email) => {
+        return this.emails.create(email)
+    }
+}

--- a/src/routes/emails.js
+++ b/src/routes/emails.js
@@ -1,0 +1,16 @@
+import { validatorMiddleware } from '../infra/validator';
+import { EmailsController } from "../controllers/EmailsController";
+import { EmailsRepository } from "../repositories/EmailsRepository";
+import { authSchema } from "../controllers/schemas/authSchema";
+
+module.exports = (app) => {
+    const emails = app.datasource.models.emails;
+    const emailsRepository = new EmailsRepository(emails);
+    const emailsController = new EmailsController(emailsRepository);
+
+    app.post('/emails', 
+            validatorMiddleware({
+                headers: authSchema
+            }),
+            emailsController.sendEmail)
+}

--- a/test/integration/routes/emails.test.js
+++ b/test/integration/routes/emails.test.js
@@ -48,11 +48,13 @@ describe('# Routes: Emails', () => {
                 request
                     .post('/emails')
                     .send(email)
-                    .set({ authorizarion: defaultUser.token })
+                    .set({ authorization: defaultUser.token })
                     .end((err, res) => {
-                        console.log(res.body);
+                        expect(res.body.from).to.be.equal(email.from)
+                        expect(res.body.to).to.be.equal(email.to)
+                        expect(res.body.subject).to.be.equal(email.subject)
                         
-                        expect(res.status).to.equal(HttpStatus.OK);
+                        expect(res.status).to.equal(HttpStatus.CREATED);
                         done(err)
                     })
             })

--- a/test/integration/routes/emails.test.js
+++ b/test/integration/routes/emails.test.js
@@ -1,0 +1,61 @@
+import HttpStatus from 'http-status'
+import { app, request, expect } from "../utils/helpers";
+import * as tokenManager from "../../../src/infra/tokenManager";
+
+describe('# Routes: Emails', () => {
+
+    describe('## POST /emails', () => {
+        
+        const defaultUser = {
+            email: 'teste@cmail.com',
+            name: 'Teste',
+            password: 'teste123',
+            avatar_url: 'http://placehold.it/200x200'
+        }
+
+        beforeEach((done) => {
+            (async () => {
+                const sequelize = app.datasource.sequelize;
+                const users = app.datasource.models.users;
+
+                await sequelize.drop()
+                await sequelize.sync()
+                await users.create(defaultUser)
+
+                done();
+            })()
+        })
+        
+        it('Should register an email object and return the date of sent and the recipient address ', (done) => {
+
+            const loginData = {
+                email: defaultUser.email,
+                password: defaultUser.password,
+            }
+            
+            tokenManager
+            .generate(loginData)
+            .then( token => defaultUser.token = token )
+            .then( () => {
+
+                const email = {
+                    from: defaultUser.email,
+                    to: 'btest@cmail.com',
+                    subject: 'Lorem',
+                    content: 'Lorem ipsum dolor sit amet consectetur adipisicing elit.'
+                }
+
+                request
+                    .post('/emails')
+                    .send(email)
+                    .set({ authorizarion: defaultUser.token })
+                    .end((err, res) => {
+                        expect(res.status).to.equal(HttpStatus.OK);
+                        done(err)
+                    })
+            })
+
+        })
+    })    
+
+})

--- a/test/integration/routes/emails.test.js
+++ b/test/integration/routes/emails.test.js
@@ -50,6 +50,8 @@ describe('# Routes: Emails', () => {
                     .send(email)
                     .set({ authorizarion: defaultUser.token })
                     .end((err, res) => {
+                        console.log(res.body);
+                        
                         expect(res.status).to.equal(HttpStatus.OK);
                         done(err)
                     })


### PR DESCRIPTION
### Descrição

Agora é possível enviar dados de um email neste formato:

```
{
  "email": "van@cmail.com",
  "name": "Vanessa",
  "password": "teste1234",
  "avatar_url": "http: //placehold.it/200x200"
}
```

### Revisão

- [ ] Precisa ter um token para enviar email
- [ ] Recebe o objeto do email como response

### Checklist pré-merge

- [ ] Verificar se esse Pull Request está alinhado com um rebase da master
- [ ] Existe algo à acrescentar na documentação?
- [ ] Fazer Squash em commits desnecessários

### Screenshots

Agora temos 9 testes :D
![testing](https://user-images.githubusercontent.com/3089882/48595677-ee4af700-e93c-11e8-856f-14b97fca5001.png)

